### PR TITLE
Allow to fully configure the provider

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,4 +28,7 @@ provider "scaffolding" {
 
 ### Optional
 
+- `api_url` (String) URL to Camunda SaaS API
+- `audience` (String) Audience of the token
 - `debug` (Boolean) Enable debug logs
+- `token_url` (String) URL to fetch token from


### PR DESCRIPTION
Hard-coded values are now default values that can be reconfigured, if needed.